### PR TITLE
chore(deps): bump parent-pom to 2.0.15, remove local jackson version overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,16 +11,13 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.8</version>
+        <version>2.0.15</version>
     </parent>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jackson-annotations.version>2.21</jackson-annotations.version>
-        <jackson2.version>2.21.2</jackson2.version>
-        <jackson3.version>3.1.2</jackson3.version>
     </properties>
 
     <scm>
@@ -129,37 +126,30 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson3.version}</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson3.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson2.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson2.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson2.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson2.version}</version>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
## Endringer

- Bumper `no.nav.eux:parent-pom` fra 2.0.8 til 2.0.15
- Fjerner lokale properties `jackson-annotations.version`, `jackson2.version`, `jackson3.version`
- Fjerner eksplisitte `<version>`-tagger fra 7 jackson2/jackson3-avhengigheter (håndteres nå av parent-pom BOM)
- Tomcat 11.0.22 er allerede inkludert via Spring Boot 4.0.7 i parent-pom 2.0.15 – ingen lokal override nødvendig